### PR TITLE
feat(update): add nightly update channel with date-based versioning and add gitee mirror for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -248,3 +248,85 @@ jobs:
           done
           
           echo "Cleanup completed" 
+
+      - name: Push nightly branch and tag to Gitee
+        if: ${{ vars.GITEE_NAMESPACE != '' }}
+        env:
+          GITEE_PRIVATE_KEY: ${{ secrets.GITEE_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$GITEE_PRIVATE_KEY" > ~/.ssh/gitee_key
+          chmod 600 ~/.ssh/gitee_key
+          ssh-keyscan gitee.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/gitee_key -o StrictHostKeyChecking=yes"
+
+          GITEE_URL="git@gitee.com:${{ vars.GITEE_NAMESPACE }}/XMCL.git"
+          git remote add gitee "$GITEE_URL" 2>/dev/null || git remote set-url gitee "$GITEE_URL"
+
+          # Force push nightly branch
+          git push gitee HEAD:refs/heads/nightly --force
+          echo "Pushed nightly branch to Gitee"
+
+          # Force push nightly tag (delete old one first to avoid conflict)
+          git push gitee :refs/tags/nightly 2>/dev/null || true
+          git push gitee refs/tags/nightly:refs/tags/nightly
+          echo "Pushed nightly tag to Gitee"
+
+      - name: Publish Nightly Release to Gitee
+        if: ${{ vars.GITEE_NAMESPACE != '' }}
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          NIGHTLY_VERSION: ${{ needs.Check-and-Prepare.outputs.nightly_version }}
+        run: |
+          OWNER="${{ vars.GITEE_NAMESPACE }}"
+          REPO="XMCL"
+          RELEASE_TITLE="XMCL Nightly (${{ env.NIGHTLY_VERSION }})"
+
+          # Delete existing nightly release on Gitee if it exists
+          EXISTING_ID=$(curl -sf \
+            "https://gitee.com/api/v5/repos/${OWNER}/${REPO}/releases/tags/nightly?access_token=${GITEE_TOKEN}" \
+            | jq -r '.id // empty' 2>/dev/null || true)
+          if [ -n "$EXISTING_ID" ]; then
+            curl -sf -X DELETE \
+              "https://gitee.com/api/v5/repos/${OWNER}/${REPO}/releases/${EXISTING_ID}?access_token=${GITEE_TOKEN}" \
+              || echo "Warning: failed to delete existing Gitee nightly release"
+            echo "Deleted existing Gitee nightly release (id: $EXISTING_ID)"
+          fi
+
+          # Create new nightly release on Gitee
+          BODY=$(python3 -c 'import sys, json; print(json.dumps(open("release_notes.md").read()))')
+          RESPONSE=$(curl -sf -X POST "https://gitee.com/api/v5/repos/${OWNER}/${REPO}/releases" \
+            -H "Content-Type: application/json" \
+            -d "{\"access_token\":\"${GITEE_TOKEN}\",\"tag_name\":\"nightly\",\"name\":\"${RELEASE_TITLE}\",\"body\":${BODY},\"prerelease\":true,\"target_commitish\":\"nightly\"}")
+          RELEASE_ID=$(echo "$RESPONSE" | jq -r '.id')
+          if [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ]; then
+            echo "Failed to create Gitee nightly release. Response: $RESPONSE"
+            exit 1
+          fi
+          echo "Created Gitee nightly release (id: $RELEASE_ID)"
+
+          # Upload all artifacts with retry
+          echo "Uploading artifacts..."
+          for f in ./artifacts/*/*; do
+            [ -f "$f" ] || continue
+            FNAME=$(basename "$f")
+            echo "  Uploading: $FNAME"
+            SUCCESS=false
+            for attempt in 1 2 3; do
+              if curl -sf -X POST \
+                "https://gitee.com/api/v5/repos/${OWNER}/${REPO}/releases/${RELEASE_ID}/attach_files" \
+                -F "access_token=${GITEE_TOKEN}" \
+                -F "file=@${f};filename=${FNAME}"; then
+                echo "  ✓ $FNAME uploaded"
+                SUCCESS=true
+                break
+              fi
+              echo "  Attempt $attempt failed, retrying in 5s..."
+              sleep 5
+            done
+            if [ "$SUCCESS" = "false" ]; then
+              echo "  ✗ Failed to upload $FNAME after 3 attempts"
+            fi
+          done
+
+          echo "Gitee nightly release published!"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       should_build: ${{ steps.check-changes.outputs.should_build }}
       nightly_version: ${{ steps.version.outputs.nightly_version }}
+      nightly_app_version: ${{ steps.version.outputs.nightly_app_version }}
       commit_hash: ${{ steps.version.outputs.commit_hash }}
     
     steps:
@@ -92,36 +93,43 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Bump version to 0.0.0
+      - name: Generate nightly version
+        id: version
         if: steps.check-changes.outputs.should_build == 'true'
         run: |
-          echo "Bumping version to 0.0.0..."
-          npm run version bump 0.0.0
+          # Get base version from main branch's package.json (nightly branch now equals main)
+          BASE_VERSION=$(cat package.json | jq -r '.version' | sed 's/-nightly-.*//')
+          NIGHTLY_DATE=$(date -u +"%y%m%d")
+          NIGHTLY_APP_VERSION="${BASE_VERSION}-nightly-${NIGHTLY_DATE}"
+          
+          # YYYYMMDD for artifact naming
+          NIGHTLY_YYYYMMDD=$(date -u +"%Y%m%d")
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          
+          echo "Base version: $BASE_VERSION"
+          echo "Nightly app version: $NIGHTLY_APP_VERSION"
+          echo "Artifact date: $NIGHTLY_YYYYMMDD"
+          echo "Commit hash: $COMMIT_HASH"
+          
+          echo "nightly_app_version=$NIGHTLY_APP_VERSION" >> $GITHUB_OUTPUT
+          echo "nightly_version=$NIGHTLY_YYYYMMDD" >> $GITHUB_OUTPUT
+          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+
+      - name: Bump version to nightly format
+        if: steps.check-changes.outputs.should_build == 'true'
+        run: |
+          NIGHTLY_APP_VERSION="${{ steps.version.outputs.nightly_app_version }}"
+          echo "Bumping version to ${NIGHTLY_APP_VERSION}..."
+          npm run version bump "${NIGHTLY_APP_VERSION}"
           
           # Commit the version change to nightly branch
           git add .
-          git commit -m "bump: version to 0.0.0 for statistics server" || echo "No changes to commit"
+          git commit -m "bump: version to ${NIGHTLY_APP_VERSION} for nightly build" || echo "No changes to commit"
           
           # Push the updated nightly branch with version bump
           git push origin refs/heads/nightly:refs/heads/nightly
           
-          echo "Version bumped to 0.0.0 and committed"
-
-      - name: Generate nightly version
-        id: version
-        run: |
-          # Get current date for nightly version
-          NIGHTLY_DATE=$(date -u +"%Y%m%d")
-          COMMIT_HASH=$(git rev-parse --short HEAD)
-          
-          # Get base version from package.json
-          NIGHTLY_VERSION="${NIGHTLY_DATE}"
-          
-          echo "Nightly version: $NIGHTLY_VERSION"
-          echo "Commit hash: $COMMIT_HASH"
-          
-          echo "nightly_version=$NIGHTLY_VERSION" >> $GITHUB_OUTPUT
-          echo "commit_hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+          echo "Version bumped to ${NIGHTLY_APP_VERSION} and committed"
 
       - name: Create and push nightly tag
         if: steps.check-changes.outputs.should_build == 'true'
@@ -167,6 +175,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: nightly
+          fetch-depth: 0
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/src-tauri/src/launcher_config/commands.rs
+++ b/src-tauri/src/launcher_config/commands.rs
@@ -7,7 +7,10 @@ use crate::launcher_config::helpers::java::{
 };
 #[cfg(target_os = "windows")]
 use crate::launcher_config::helpers::updater::install_update_windows;
-use crate::launcher_config::helpers::updater::{download_target_version, fetch_latest_version};
+use crate::launcher_config::helpers::updater::{
+  download_nightly_target_version, download_target_version, fetch_latest_version,
+  fetch_nightly_version,
+};
 use crate::launcher_config::models::{
   GameDirectory, JavaInfo, LauncherConfig, LauncherConfigError, VersionMetaInfo,
 };
@@ -250,7 +253,25 @@ pub async fn check_launcher_update(app: AppHandle) -> XMCLResult<VersionMetaInfo
     config_state.basic_info.launcher_version.clone()
   };
 
-  // skip non-semver versions
+  // Handle nightly versions separately via the nightly release channel
+  if current_version.contains("-nightly-") {
+    return match fetch_nightly_version(&app, &current_version).await {
+      Ok(Some((new_version, fname, release_notes, published_at))) => Ok(VersionMetaInfo {
+        version: new_version,
+        file_name: fname,
+        release_notes,
+        published_at,
+        is_nightly: true,
+      }),
+      Ok(None) => Ok(VersionMetaInfo {
+        version: "up2date".to_string(),
+        ..Default::default()
+      }),
+      Err(_) => Ok(VersionMetaInfo::default()),
+    };
+  }
+
+  // Skip non-semver versions (e.g. "dev", legacy "nightly")
   if semver::Version::parse(&current_version).is_err() {
     return Ok(VersionMetaInfo::default());
   }
@@ -268,6 +289,7 @@ pub async fn check_launcher_update(app: AppHandle) -> XMCLResult<VersionMetaInfo
           file_name: fname,
           release_notes,
           published_at,
+          is_nightly: false,
         },
         std::cmp::Ordering::Equal => VersionMetaInfo {
           version: "up2date".to_string(),
@@ -289,10 +311,13 @@ pub async fn test_proxy_connection(app: AppHandle, test_url: String) -> XMCLResu
 #[tauri::command]
 pub async fn download_launcher_update(app: AppHandle, version: VersionMetaInfo) -> XMCLResult<()> {
   if version.version.is_empty() || version.version == "up2date" {
-    Ok(())
+    return Ok(());
+  }
+  if version.is_nightly {
+    download_nightly_target_version(&app, version.file_name).await
   } else {
     // TODO: handle already downloaded case
-    return download_target_version(&app, version.version, version.file_name).await;
+    download_target_version(&app, version.version, version.file_name).await
   }
 }
 

--- a/src-tauri/src/launcher_config/helpers/updater.rs
+++ b/src-tauri/src/launcher_config/helpers/updater.rs
@@ -36,6 +36,30 @@ const SOURCES: [SourceTuple; 2] = [
   ),
 ];
 
+// Nightly release channel: uses the rolling "nightly" tag
+const NIGHTLY_SOURCES: [SourceTuple; 2] = [
+  (
+    "https://gitee.com/api/v5/repos/origin173/XMCL/releases/tags/nightly",
+    "tag_name",
+    |_ver, fname| {
+      format!(
+        "https://gitee.com/origin173/XMCL/releases/download/nightly/{}",
+        fname
+      )
+    },
+  ),
+  (
+    "https://api.github.com/repos/Origin173/XMCL/releases/tags/nightly",
+    "tag_name",
+    |_ver, fname| {
+      format!(
+        "https://github.com/Origin173/XMCL/releases/download/nightly/{}",
+        fname
+      )
+    },
+  ),
+];
+
 // Generate the new version filename on remote origin according to the current os, arch and is_portable
 fn build_resource_filename(ver: &str, os: &str, arch: &str, is_portable: bool) -> String {
   let arch = if arch == "x86" { "i686" } else { arch };
@@ -52,6 +76,29 @@ fn build_resource_filename(ver: &str, os: &str, arch: &str, is_portable: bool) -
     _ => "",
   };
   format!("XMCL_{}_{}_{}{}", ver, os, arch, suffix)
+}
+
+// Constructs the nightly artifact filename using YYYYMMDD date
+fn build_nightly_resource_filename(
+  yyyymmdd: &str,
+  os: &str,
+  arch: &str,
+  is_portable: bool,
+) -> String {
+  let arch = if arch == "x86" { "i686" } else { arch };
+  let suffix = match os {
+    "windows" => {
+      if is_portable {
+        "_portable.exe"
+      } else {
+        ".msi"
+      }
+    }
+    "linux" => ".AppImage",
+    "macos" => ".app.tar.gz",
+    _ => "",
+  };
+  format!("XMCL_nightly_{}_{}_{}{}", yyyymmdd, os, arch, suffix)
 }
 
 fn build_local_new_filename(old_name: &str, old_version: &str, new_version: &str) -> String {
@@ -116,6 +163,82 @@ pub async fn fetch_latest_version(
   Err(LauncherConfigError::FetchError.into())
 }
 
+// Fetch nightly release info and compare with current version's embedded date.
+// Returns Ok(Some(...)) if a newer nightly is available,
+//         Ok(None)      if already up-to-date,
+//         Err(...)      if the fetch failed.
+pub async fn fetch_nightly_version(
+  app: &AppHandle,
+  current_version: &str,
+) -> XMCLResult<Option<(String, String, String, String)>> {
+  let config_binding = app.state::<Mutex<LauncherConfig>>();
+  let (os, arch, is_portable, is_china_mainland_ip) = {
+    let config_state = config_binding.lock()?;
+    (
+      config_state.basic_info.os_type.clone(),
+      config_state.basic_info.arch.clone(),
+      config_state.basic_info.is_portable,
+      config_state.basic_info.is_china_mainland_ip,
+    )
+  };
+  let client = app.state::<reqwest::Client>();
+
+  let mut sources = NIGHTLY_SOURCES;
+  if !is_china_mainland_ip {
+    sources.reverse();
+  }
+
+  for (endpoint, _, _mk_url) in sources {
+    if let Ok(resp) = client.get(endpoint).send().await {
+      if let Ok(j) = resp.json::<Value>().await {
+        if let Some(published_at) = j.get("published_at").and_then(|v| v.as_str()) {
+          // Extract YYYYMMDD from "2026-01-10T00:00:00Z"
+          let yyyymmdd: String = published_at
+            .chars()
+            .filter(|c| c.is_ascii_digit())
+            .take(8)
+            .collect();
+          if yyyymmdd.len() < 8 {
+            continue;
+          }
+          let yymmdd = &yyyymmdd[2..]; // "260110"
+
+          // Extract current nightly date from version string, e.g. "0.1.0-nightly-260110"
+          let current_yymmdd = current_version
+            .split("-nightly-")
+            .nth(1)
+            .unwrap_or("000000");
+
+          if yymmdd <= current_yymmdd {
+            return Ok(None); // already up-to-date
+          }
+
+          // Derive the base version (strip any existing pre-release suffix)
+          let base_version = current_version.split("-nightly-").next().unwrap_or("0.0.0");
+          let new_version = format!("{}-nightly-{}", base_version, yymmdd);
+
+          let fname =
+            build_nightly_resource_filename(&yyyymmdd, os.as_str(), arch.as_str(), is_portable);
+          let release_notes = j
+            .get("body")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+
+          return Ok(Some((
+            new_version,
+            fname,
+            release_notes,
+            published_at.to_string(),
+          )));
+        }
+      }
+    }
+  }
+
+  Err(LauncherConfigError::FetchError.into())
+}
+
 pub async fn download_target_version(
   app: &AppHandle,
   version: String,
@@ -141,6 +264,49 @@ pub async fn download_target_version(
     if let Ok(resp) = client.get(endpoint).send().await {
       if resp.status().is_success() {
         let url = mk_url(&version, &fname);
+
+        schedule_progressive_task_group(
+          app.clone(),
+          format!("launcher-update?{}", fname),
+          vec![PTaskParam::Download(DownloadParam {
+            src: url::Url::parse(&url).map_err(|_| LauncherConfigError::FetchError)?,
+            dest: download_cache_dir.join(&fname),
+            filename: Some(fname),
+            sha1: None,
+          })],
+          true,
+        )
+        .await?;
+
+        return Ok(());
+      }
+    }
+  }
+
+  Err(LauncherConfigError::FetchError.into())
+}
+
+pub async fn download_nightly_target_version(app: &AppHandle, fname: String) -> XMCLResult<()> {
+  let config_binding = app.state::<Mutex<LauncherConfig>>();
+  let (download_cache_dir, is_china_mainland_ip) = {
+    let config_state = config_binding.lock()?;
+    (
+      config_state.download.cache.directory.clone(),
+      config_state.basic_info.is_china_mainland_ip,
+    )
+  };
+
+  let client = app.state::<reqwest::Client>();
+
+  let mut sources = NIGHTLY_SOURCES;
+  if !is_china_mainland_ip {
+    sources.reverse();
+  }
+
+  for (endpoint, _, mk_url) in sources {
+    if let Ok(resp) = client.get(endpoint).send().await {
+      if resp.status().is_success() {
+        let url = mk_url("", &fname);
 
         schedule_progressive_task_group(
           app.clone(),
@@ -202,7 +368,13 @@ pub async fn install_update_windows(
       .ok_or_else(|| XMCLError("Invalid exe name".to_string()))?
       .to_string();
 
-    let target_name = build_local_new_filename(&old_name, &old_version, &new_version);
+    // For nightly builds the downloaded file already has the correct date-based name,
+    // so place it directly using that name to keep proper versioning.
+    let target_name = if downloaded_filename.contains("_nightly_") {
+      downloaded_filename.clone()
+    } else {
+      build_local_new_filename(&old_name, &old_version, &new_version)
+    };
     let target = cur_dir.join(target_name);
     let pid = std::process::id().to_string();
     let restart_flag = if restart { "1" } else { "0" };
@@ -314,7 +486,12 @@ pub async fn install_update_macos(
     .ok_or_else(|| XMCLError("Invalid .app name".to_string()))?
     .to_string();
 
-  let target_name = build_local_new_filename(&old_name, &old_version, &new_version);
+  // For nightly builds the downloaded file already carries the correct date-based name
+  let target_name = if downloaded_filename.contains("_nightly_") {
+    downloaded_filename.clone()
+  } else {
+    build_local_new_filename(&old_name, &old_version, &new_version)
+  };
   let target_app = app_dir.join(target_name);
   let pid = std::process::id().to_string();
   let restart_flag = if restart { "1" } else { "0" };

--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -38,6 +38,7 @@ pub struct VersionMetaInfo {
   pub file_name: String,
   pub release_notes: String,
   pub published_at: String,
+  pub is_nightly: bool,
 }
 
 // https://github.com/HMCL-dev/HMCL/blob/d9e3816b8edf9e7275e4349d4fc67a5ef2e3c6cf/HMCLCore/src/main/java/org/jackhuang/hmcl/game/ProcessPriority.java#L20

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -308,6 +308,7 @@ export interface VersionMetaInfo {
   fileName: string;
   releaseNotes?: string;
   publishedAt?: string;
+  isNightly?: boolean;
 }
 
 // empty release meta info indicating up-to-date or error.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #21

### Description

添加了 Nightly 更新渠道，解决了此前 nightly 构建版本号过于粗糙（0.0.0）以及无法在应用内检查更新的问题。

主要改动：

版本号格式变更：Nightly 构建从 0.0.0 改为 BASE-nightly-YYMMDD 格式（如 0.1.1-nightly-260403），在"关于"页面准确显示具体 nightly 版本

下载与安装修复：修复 Windows/macOS 便携版安装时文件名错误的问题——Nightly 构建的 artifact 文件名已包含正确的日期，直接用作目标文件名

CI/CD 同步至 Gitee：nightly.yml 构建完成后，将 nightly 分支和 tag 强制推送至 Gitee，并通过 Gitee REST API 创建/更新 nightly prerelease、上传所有构建产物

### Additional Context

> - Add any other relevant information or screenshots here.

