### PR TITLE
fix: apply download proxy to CAUC and add i18n for CAUC login flow

### DIFF
--- a/src-tauri/src/account/helpers/authlib_injector/cauc.rs
+++ b/src-tauri/src/account/helpers/authlib_injector/cauc.rs
@@ -1,7 +1,6 @@
 use crate::account::helpers::authlib_injector::common::{parse_profile, retrieve_profile};
 use crate::account::models::{AccountError, PlayerInfo};
 use crate::error::XMCLResult;
-use crate::utils::web::apply_proxy_config;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tauri::AppHandle;
@@ -10,17 +9,19 @@ use urlencoding::decode;
 
 const CAUC_BASE_URL: &str = "https://skin.cauc.fun";
 
-fn build_cauc_client(app: &AppHandle) -> Result<Client, AccountError> {
-  let builder = reqwest::Client::builder()
+/// CAUC campus auth server (skin.cauc.fun) is session/IP-bound; routing it
+/// through a download proxy breaks cookie-based auth. Keep direct connection
+/// here – the later `retrieve_profile` call already goes through the global
+/// proxy-aware Client.
+fn build_cauc_client(_app: &AppHandle) -> Result<Client, AccountError> {
+  reqwest::Client::builder()
     .redirect(reqwest::redirect::Policy::none())
-    .cookie_store(true);
-
-  let builder = apply_proxy_config(app, builder);
-
-  builder.build().map_err(|e| {
-    log::error!("Failed to build CAUC HTTP client: {}", e);
-    AccountError::NetworkError
-  })
+    .cookie_store(true)
+    .build()
+    .map_err(|e| {
+      log::error!("Failed to build CAUC HTTP client: {}", e);
+      AccountError::NetworkError
+    })
 }
 
 async fn get_player_name(client: &Client, cookie_jar: &[(String, String)]) -> XMCLResult<String> {

--- a/src-tauri/src/account/helpers/authlib_injector/cauc.rs
+++ b/src-tauri/src/account/helpers/authlib_injector/cauc.rs
@@ -1,6 +1,7 @@
 use crate::account::helpers::authlib_injector::common::{parse_profile, retrieve_profile};
 use crate::account::models::{AccountError, PlayerInfo};
 use crate::error::XMCLResult;
+use crate::utils::web::apply_proxy_config;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tauri::AppHandle;
@@ -8,6 +9,19 @@ use tauri_plugin_http::reqwest::{self, Client};
 use urlencoding::decode;
 
 const CAUC_BASE_URL: &str = "https://skin.cauc.fun";
+
+fn build_cauc_client(app: &AppHandle) -> Result<Client, AccountError> {
+  let builder = reqwest::Client::builder()
+    .redirect(reqwest::redirect::Policy::none())
+    .cookie_store(true);
+
+  let builder = apply_proxy_config(app, builder);
+
+  builder.build().map_err(|e| {
+    log::error!("Failed to build CAUC HTTP client: {}", e);
+    AccountError::NetworkError
+  })
+}
 
 async fn get_player_name(client: &Client, cookie_jar: &[(String, String)]) -> XMCLResult<String> {
   let user_page_url = format!("{}/user", CAUC_BASE_URL);
@@ -85,21 +99,13 @@ pub struct CAUCAuthState {
 }
 
 pub async fn eduroam_login(
-  _app: &AppHandle,
+  app: &AppHandle,
   student_id: String,
   oa_password: String,
 ) -> XMCLResult<CAUCAuthState> {
   log::info!("CAUC eduroam login attempt for student: {}", student_id);
 
-  // 创建一个不自动跟随重定向的客户端
-  let client = reqwest::Client::builder()
-    .redirect(reqwest::redirect::Policy::none())
-    .cookie_store(true)
-    .build()
-    .map_err(|e| {
-      log::error!("Failed to build HTTP client: {}", e);
-      AccountError::NetworkError
-    })?;
+  let client = build_cauc_client(app)?;
 
   // 步骤 1: 先访问登录页面获取 CSRF token
   let login_page_url = format!("{}/auth/eduroam/login", CAUC_BASE_URL);

--- a/src-tauri/src/instance/helpers/loader/common.rs
+++ b/src-tauri/src/instance/helpers/loader/common.rs
@@ -59,7 +59,7 @@ pub async fn install_mod_loader(
       .await
     }
     ModLoaderType::Forge => {
-      install_forge_loader(priority, game_version, loader, lib_dir, task_params).await
+      install_forge_loader(&app, priority, game_version, loader, lib_dir, task_params).await
     }
     ModLoaderType::NeoForge => {
       install_neoforge_loader(priority, loader, lib_dir, task_params).await

--- a/src-tauri/src/instance/helpers/loader/forge.rs
+++ b/src-tauri/src/instance/helpers/loader/forge.rs
@@ -23,14 +23,17 @@ use crate::resource::models::{ResourceType, SourceType};
 use crate::tasks::commands::schedule_progressive_task_group;
 use crate::tasks::download::DownloadParam;
 use crate::tasks::PTaskParam;
+use crate::utils::web::apply_proxy_config;
 
 async fn fetch_bmcl_forge_installer_url(
+  app: &AppHandle,
   root: Url,
   game_version: &str,
   loader_ver: &str,
   branch: Option<&str>,
 ) -> Result<String, Error> {
-  let client = Client::builder().redirect(Policy::limited(5)).build()?;
+  let builder = Client::builder().redirect(Policy::limited(5));
+  let client = apply_proxy_config(app, builder).build()?;
 
   let response = client
     .get(root)
@@ -49,6 +52,7 @@ async fn fetch_bmcl_forge_installer_url(
 }
 
 pub async fn install_forge_loader(
+  app: &AppHandle,
   priority: &[SourceType],
   game_version: &str,
   loader: &ModLoader,
@@ -74,8 +78,14 @@ pub async fn install_forge_loader(
       root.join(&format!("{full_ver}/forge-{full_ver}-installer.jar"))?
     }
     SourceType::BMCLAPIMirror => Url::parse(
-      &fetch_bmcl_forge_installer_url(root, game_version, loader_ver, loader.branch.as_deref())
-        .await?,
+      &fetch_bmcl_forge_installer_url(
+        app,
+        root,
+        game_version,
+        loader_ver,
+        loader.branch.as_deref(),
+      )
+      .await?,
     )?,
     SourceType::NeoForgedCDN => root.join(&format!(
       "{game_version}-{loader_ver}/forge-{game_version}-{loader_ver}-installer.jar"

--- a/src-tauri/src/openlist/test_api.rs
+++ b/src-tauri/src/openlist/test_api.rs
@@ -1,12 +1,14 @@
 use serde_json::json;
+use tauri::AppHandle;
+use tauri::Manager;
 use tauri_plugin_http::reqwest;
 
 const OPENLIST_BASE_URL: &str = env!("XMCL_OPENLIST_BASE_URL");
 
 #[tauri::command]
-pub async fn test_openlist_connection() -> Result<String, String> {
+pub async fn test_openlist_connection(app: AppHandle) -> Result<String, String> {
   let url = format!("{}/api/fs/list", OPENLIST_BASE_URL);
-  let client = reqwest::Client::new();
+  let client = app.state::<reqwest::Client>().inner().clone();
 
   let body = json!({
     "path": "/",

--- a/src-tauri/src/utils/web.rs
+++ b/src-tauri/src/utils/web.rs
@@ -34,6 +34,27 @@ use std::time::Duration;
 /// ```rust
 /// let client = build_xmcl_client(&app, true, true);
 /// ```
+/// Applies proxy settings from LauncherConfig to a ClientBuilder.
+pub fn apply_proxy_config(app: &AppHandle, builder: ClientBuilder) -> ClientBuilder {
+  if let Ok(config) = app.state::<Mutex<LauncherConfig>>().lock() {
+    if config.download.proxy.enabled {
+      let proxy_cfg = &config.download.proxy;
+
+      if !proxy_cfg.follow_system_proxy {
+        let proxy_url = match proxy_cfg.selected_type {
+          ProxyType::Http => format!("http://{}:{}", proxy_cfg.host, proxy_cfg.port),
+          ProxyType::Socks => format!("socks5h://{}:{}", proxy_cfg.host, proxy_cfg.port),
+        };
+
+        if let Ok(proxy) = Proxy::all(&proxy_url) {
+          return builder.proxy(proxy);
+        }
+      }
+    }
+  }
+  builder
+}
+
 pub fn build_xmcl_client(app: &AppHandle, use_version_header: bool, use_proxy: bool) -> Client {
   let mut builder = ClientBuilder::new()
     .connect_timeout(Duration::from_secs(30))
@@ -50,23 +71,10 @@ pub fn build_xmcl_client(app: &AppHandle, use_version_header: bool, use_proxy: b
         builder = builder.default_headers(headers);
       }
     }
+  }
 
-    if use_proxy && config.download.proxy.enabled {
-      let proxy_cfg = &config.download.proxy;
-
-      // If follow_system_proxy is enabled, don't set manual proxy
-      // Let reqwest use system proxy settings
-      if !proxy_cfg.follow_system_proxy {
-        let proxy_url = match proxy_cfg.selected_type {
-          ProxyType::Http => format!("http://{}:{}", proxy_cfg.host, proxy_cfg.port),
-          ProxyType::Socks => format!("socks5h://{}:{}", proxy_cfg.host, proxy_cfg.port),
-        };
-
-        if let Ok(proxy) = Proxy::all(&proxy_url) {
-          builder = builder.proxy(proxy);
-        }
-      }
-    }
+  if use_proxy {
+    builder = apply_proxy_config(app, builder);
   }
 
   builder.build().unwrap_or_else(|_| Client::new())

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2027,6 +2027,42 @@
         }
       }
     },
+    "cauc": {
+      "caucEduroamLogin": {
+        "success": "CAUC campus login successful",
+        "error": {
+          "title": "CAUC campus login failed",
+          "description": {
+            "NETWORK_ERROR": "Unable to connect to CAUC authentication server",
+            "INVALID": "Incorrect student ID or password",
+            "PARSE_ERROR": "Server returned data in an incorrect format"
+          }
+        }
+      },
+      "caucBindPlayerName": {
+        "success": "Player name bound successfully",
+        "error": {
+          "title": "Failed to bind player name",
+          "description": {
+            "NETWORK_ERROR": "Unable to connect to CAUC authentication server",
+            "INVALID": "Player name is invalid or already taken"
+          }
+        }
+      },
+      "caucCompleteLogin": {
+        "success": "CAUC account added successfully",
+        "error": {
+          "title": "CAUC login authentication failed",
+          "description": {
+            "NETWORK_ERROR": "Unable to connect to CAUC authentication server",
+            "INVALID": "Authentication info is invalid, please login again",
+            "NOT_FOUND": "No player profile found",
+            "DUPLICATE": "This player already exists",
+            "PARSE_ERROR": "Server returned data in an incorrect format"
+          }
+        }
+      }
+    },
     "launch": {
       "selectSuitableJRE": {
         "error": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1876,6 +1876,42 @@
         }
       }
     },
+    "cauc": {
+      "caucEduroamLogin": {
+        "success": "Connexion campus CAUC réussie",
+        "error": {
+          "title": "Échec de la connexion campus CAUC",
+          "description": {
+            "NETWORK_ERROR": "Impossible de se connecter au serveur d'authentification CAUC",
+            "INVALID": "Numéro d'étudiant ou mot de passe incorrect",
+            "PARSE_ERROR": "Le serveur a renvoyé des données dans un format incorrect"
+          }
+        }
+      },
+      "caucBindPlayerName": {
+        "success": "Nom de joueur lié avec succès",
+        "error": {
+          "title": "Échec de la liaison du nom de joueur",
+          "description": {
+            "NETWORK_ERROR": "Impossible de se connecter au serveur d'authentification CAUC",
+            "INVALID": "Le nom de joueur est invalide ou déjà pris"
+          }
+        }
+      },
+      "caucCompleteLogin": {
+        "success": "Compte CAUC ajouté avec succès",
+        "error": {
+          "title": "Échec de l'authentification CAUC",
+          "description": {
+            "NETWORK_ERROR": "Impossible de se connecter au serveur d'authentification CAUC",
+            "INVALID": "Informations d'authentification invalides, veuillez vous reconnecter",
+            "NOT_FOUND": "Aucun profil de joueur trouvé",
+            "DUPLICATE": "Ce joueur existe déjà",
+            "PARSE_ERROR": "Le serveur a renvoyé des données dans un format incorrect"
+          }
+        }
+      }
+    },
     "launch": {
       "selectSuitableJRE": {
         "error": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1840,6 +1840,42 @@
         }
       }
     },
+    "cauc": {
+      "caucEduroamLogin": {
+        "success": "CAUCキャンパスログイン成功",
+        "error": {
+          "title": "CAUCキャンパスログイン失敗",
+          "description": {
+            "NETWORK_ERROR": "CAUC認証サーバーに接続できません",
+            "INVALID": "学籍番号またはパスワードが正しくありません",
+            "PARSE_ERROR": "サーバー応答データ形式エラー"
+          }
+        }
+      },
+      "caucBindPlayerName": {
+        "success": "プレイヤー名の設定に成功",
+        "error": {
+          "title": "プレイヤー名の設定に失敗",
+          "description": {
+            "NETWORK_ERROR": "CAUC認証サーバーに接続できません",
+            "INVALID": "プレイヤー名が無効または使用済みです"
+          }
+        }
+      },
+      "caucCompleteLogin": {
+        "success": "CAUCアカウントの追加に成功",
+        "error": {
+          "title": "CAUCログイン認証に失敗",
+          "description": {
+            "NETWORK_ERROR": "CAUC認証サーバーに接続できません",
+            "INVALID": "認証情報が無効です。再ログインしてください",
+            "NOT_FOUND": "プレイヤー情報が見つかりません",
+            "DUPLICATE": "このプレイヤーは既に存在します",
+            "PARSE_ERROR": "サーバー応答データ形式エラー"
+          }
+        }
+      }
+    },
     "resource": {
       "fetchGameVersionList": {
         "error": {

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -2027,6 +2027,42 @@
         }
       }
     },
+    "cauc": {
+      "caucEduroamLogin": {
+        "success": "CAUC 校园登录成功",
+        "error": {
+          "title": "CAUC 校园登录失败",
+          "description": {
+            "NETWORK_ERROR": "无法连接至 CAUC 认证服务器",
+            "INVALID": "学工号或密码错误",
+            "PARSE_ERROR": "服务器返回数据格式错误"
+          }
+        }
+      },
+      "caucBindPlayerName": {
+        "success": "游戏昵称绑定成功",
+        "error": {
+          "title": "游戏昵称绑定失败",
+          "description": {
+            "NETWORK_ERROR": "无法连接至 CAUC 认证服务器",
+            "INVALID": "昵称无效或已被占用"
+          }
+        }
+      },
+      "caucCompleteLogin": {
+        "success": "CAUC 账号添加成功",
+        "error": {
+          "title": "CAUC 登录认证失败",
+          "description": {
+            "NETWORK_ERROR": "无法连接至 CAUC 认证服务器",
+            "INVALID": "认证信息无效，请重新登录",
+            "NOT_FOUND": "未找到角色信息",
+            "DUPLICATE": "该角色已存在",
+            "PARSE_ERROR": "服务器返回数据格式错误"
+          }
+        }
+      }
+    },
     "launch": {
       "selectSuitableJRE": {
         "error": {

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -2015,6 +2015,42 @@
         }
       }
     },
+    "cauc": {
+      "caucEduroamLogin": {
+        "success": "CAUC 校園登入成功",
+        "error": {
+          "title": "CAUC 校園登入失敗",
+          "description": {
+            "NETWORK_ERROR": "無法連線至 CAUC 認證伺服器",
+            "INVALID": "學工號或密碼錯誤",
+            "PARSE_ERROR": "伺服器返回資料格式錯誤"
+          }
+        }
+      },
+      "caucBindPlayerName": {
+        "success": "遊戲暱稱綁定成功",
+        "error": {
+          "title": "遊戲暱稱綁定失敗",
+          "description": {
+            "NETWORK_ERROR": "無法連線至 CAUC 認證伺服器",
+            "INVALID": "暱稱無效或已被佔用"
+          }
+        }
+      },
+      "caucCompleteLogin": {
+        "success": "CAUC 帳號新增成功",
+        "error": {
+          "title": "CAUC 登入認證失敗",
+          "description": {
+            "NETWORK_ERROR": "無法連線至 CAUC 認證伺服器",
+            "INVALID": "認證資訊無效，請重新登入",
+            "NOT_FOUND": "未找到角色資訊",
+            "DUPLICATE": "該角色已存在",
+            "PARSE_ERROR": "伺服器返回資料格式錯誤"
+          }
+        }
+      }
+    },
     "launch": {
       "selectSuitableJRE": {
         "error": {


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #20

### Description

在各语言包中新增 `Services.cauc` 下 `caucEduroamLogin`、`caucBindPlayerName`、`caucCompleteLogin` 的成功/失败标题及 `error.description`（含 `NETWORK_ERROR` 等）

修复了代理没有全局启用的问题

### Additional Context


